### PR TITLE
Fix Japanese comment for batch files

### DIFF
--- a/src/validate.lisp
+++ b/src/validate.lisp
@@ -129,7 +129,7 @@
               (format t "~a No valid video files found in directory '~a'.~%" (log-tag "error") input)
               (uiop:quit 1))
 
-            ;; batch-files にファイル名(string型格納
+            ;; batch-files にファイル名 (string 型) を格納
             (setf (visp-options-batch-files opts) (mapcar #'namestring files))
 
             (format t "~a Batch mode: ~a video file(s) found in directory.~%" (log-tag "info") (length files))))


### PR DESCRIPTION
## Summary
- update the Japanese comment near line 132 in `src/validate.lisp`

## Testing
- `make test` *(fails: `ros` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff7893da08324aecb271bc4ca3027