### PR TITLE
Fix reverse help message

### DIFF
--- a/src/help.lisp
+++ b/src/help.lisp
@@ -21,7 +21,7 @@
   (format t "  --fps <number>        Set output framerate (e.g., 30)~%")
   (format t "  --codec <type>        Set codec (h264, h265, prores, hap, vp8, vp9)~%")
   (format t "  --mono                Convert to grayscale (h264/h265 only)~%")
-  (format t "  --reverse             Reverse video playback (audio unaffected)~%")
+  (format t "  --reverse             Reverse video playback (audio is automatically muted)~%")
   (format t "  --loop <n>            Loop playback n times (e.g., 3 = 4 total plays)~%")
   (format t "  --mute                Remove audio track~%")
   (format t "  --dry-run             Show ffmpeg command without executing~%")


### PR DESCRIPTION
## Summary
- clarify that `--reverse` automatically mutes audio

## Testing
- `make test` *(fails: ros not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ff7b2160c8324bb40ea7682d77a1f