### PR TITLE
Allow WxH for --res option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Originally created as a Lisp learning project, `visp` has grown into a practical
 # Downscale a 4K video to 1080p and remove audio
 visp --input sample_4k.mp4 --res fhd --mute
 
+# Specify resolution explicitly with width and height
+visp --input clip.mp4 --res 1280x720
+
 # Transcode to HAP codec, preserving resolution and audio
 visp --input sample.mov --codec hap
 
@@ -61,7 +64,7 @@ Examples:
 | Option      | Argument                                      | Description                                                      |
 | ----------- | --------------------------------------------- | ---------------------------------------------------------------- |
 | `--input`   | `<file or directory>`                         | **Required.** Path to the input video file or directory.         |
-| `--res`     | `hd`, `fhd`, `2k`, `4k`, `8k`                 | Target resolution (e.g. `fhd` → 1920×1080).                      |
+| `--res`     | `hd`, `fhd`, `2k`, `4k`, `8k`, `<WxH>`        | Target resolution (e.g. `fhd` or `1920x1080`).                   |
 | `--codec`   | `h264`, `h265`, `prores`, `hap`, `vp8`, `vp9` | Video codec (also determines container and pixel format).        |
 | `--fps`     | `<number>`                                    | Set output framerate (e.g. 24, 30, 60).                          |
 | `--mute`    | _(flag)_                                      | Strip out the audio track.                                       |

--- a/src/help.lisp
+++ b/src/help.lisp
@@ -16,7 +16,7 @@
   (format t "  --input <file>        Input video file or directory (required)~%")
   (format t "                        - If a directory is specified, all video files in it will be processed in batch.~%")
   (format t "                        - Output files will be placed in the same directory as input files.~%")
-  (format t "  --res <label>         Set resolution (hd, fhd, 2k, 4k, etc)~%")
+  (format t "  --res <label|WxH>    Set resolution (e.g., fhd or 1280x720)~%")
   (format t "  --half                Downscale to half resolution~%")
   (format t "  --fps <number>        Set output framerate (e.g., 30)~%")
   (format t "  --codec <type>        Set codec (h264, h265, prores, hap, vp8, vp9)~%")

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -35,6 +35,7 @@
    :parse-float
    :parse-frame-rate
    :resolution-from-key
+   :parse-dimensions
    :codec-info-from-key
    :generate-output-filename
    :generate-merge-output-filename

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -37,6 +37,17 @@
   "Return (width . height) if key is valid; otherwise NIL"
   (assoc key +resolution-map+ :test #'string-equal))
 
+(defun parse-dimensions (str)
+  "Parse WIDTHxHEIGHT string and return cons (width . height).
+Accepts integers including -1. Returns NIL on malformed input."
+  (let ((parts (uiop:split-string str :separator "x")))
+    (when (= (length parts) 2)
+      (handler-case
+          (let ((w (parse-integer (string-trim '(#\Space) (first parts))))
+                (h (parse-integer (string-trim '(#\Space) (second parts)))))
+            (cons w h))
+        (error () nil)))))
+
 (defun codec-info-from-key (key)
   "Return plist (:encoder \"libx264\" :ext \"mp4\") if key is valid; otherwise NIL."
   (cdr (assoc key +codec-map+ :test #'string-equal)))

--- a/src/validate.lisp
+++ b/src/validate.lisp
@@ -207,9 +207,11 @@
 
     ;; --res が指定されていれば有効な解像度か確認
     (when res
-      (let ((pair (resolution-from-key res)))
-        (if pair
-            (setf (visp-options-scale opts) (cdr pair)) ; 正常なら scale にセット
+      (let* ((pair (resolution-from-key res))
+             (dims (or (and pair (cdr pair))
+                       (parse-dimensions res))))
+        (if dims
+            (setf (visp-options-scale opts) dims)
             (progn
               (format t "~a visp does not support the resolution '~a'.~%"
                       (log-tag "error") res)

--- a/t/test-util.lisp
+++ b/t/test-util.lisp
@@ -35,6 +35,15 @@
     (ok (null (visp:resolution-from-key "unknown")))
     (ok (null (visp:resolution-from-key "")))))
 
+(deftest parse-dimensions-tests
+  (testing "Parses valid WxH strings"
+    (ok (equal (visp:parse-dimensions "1920x1080") '(1920 . 1080)))
+    (ok (equal (visp:parse-dimensions "1280x-1") '(1280 . -1))))
+
+  (testing "Returns NIL for malformed strings"
+    (ok (null (visp:parse-dimensions "1920*1080")))
+    (ok (null (visp:parse-dimensions "x720")))))
+
 (deftest codec-info-from-key-tests
   (testing "Returns correct plist for known codecs"
     (ok (equalp (visp:codec-info-from-key "h264")


### PR DESCRIPTION
## Summary
- support numeric resolution (widthxheight) via `--res`
- document new usage in README and `--help`
- expose `parse-dimensions` util and validate it
- add tests for numeric resolution parsing

## Testing
- `make test` *(fails: ros not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff74e9ef08324a541be4a2e38e0cb