### PR TITLE
refactor: 出力ファイル名生成関数の引数を統一

### DIFF
--- a/src/main.lisp
+++ b/src/main.lisp
@@ -21,7 +21,7 @@
       ((visp-options-gif opts)
        (let* ((input (visp-options-input opts))
               (fps (get-video-fps input)) 
-              (output (generate-gif-output-filename input opts))
+              (output (generate-gif-output-filename opts))
               (cmd (build-gif-cmd opts output fps)))
          (run-cmd cmd output (visp-options-dry-run opts))))
 

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -52,11 +52,12 @@ Accepts integers including -1. Returns NIL on malformed input."
   "Return plist (:encoder \"libx264\" :ext \"mp4\") if key is valid; otherwise NIL."
   (cdr (assoc key +codec-map+ :test #'string-equal)))
 
-(defun generate-gif-output-filename (input &optional opts)
+(defun generate-gif-output-filename (opts)
   "Generate a .gif filename from the input video filename, or return custom output if specified."
-  (if (and opts (visp-options-output opts))
+  (if (visp-options-output opts)
       (visp-options-output opts)
-      (let* ((base (file-namestring input))
+      (let* ((input (visp-options-input opts))
+             (base (file-namestring input))
              (dot-pos (position #\. base :from-end t))
              (name (subseq base 0 dot-pos)))
         (concatenate 'string name ".gif"))))

--- a/t/test-util.lisp
+++ b/t/test-util.lisp
@@ -149,16 +149,20 @@
 (deftest generate-gif-output-filename-with-output-option-tests
   (testing "GIF output filename with --output option"
     ;; --outputが指定されていない場合の従来動作
-    (ok (string= (visp:generate-gif-output-filename "test.mp4" nil) "test.gif"))
+    (let ((opts (visp:make-visp-options)))
+      (setf (visp:visp-options-input opts) "test.mp4")
+      (ok (string= (visp:generate-gif-output-filename opts) "test.gif")))
     
     ;; --outputが指定されている場合
     (let ((opts (visp:make-visp-options)))
+      (setf (visp:visp-options-input opts) "test.mp4")
       (setf (visp:visp-options-output opts) "custom.gif")
-      (ok (string= (visp:generate-gif-output-filename "test.mp4" opts) "custom.gif")))
+      (ok (string= (visp:generate-gif-output-filename opts) "custom.gif")))
     
     ;; --outputが指定されていない場合
     (let ((opts (visp:make-visp-options)))
-      (ok (string= (visp:generate-gif-output-filename "test.mp4" opts) "test.gif")))))
+      (setf (visp:visp-options-input opts) "test.mp4")
+      (ok (string= (visp:generate-gif-output-filename opts) "test.gif")))))
 
 (deftest generate-merge-output-filename-with-output-option-tests
   (testing "Merge output filename with --output option"


### PR DESCRIPTION
## 概要
出力ファイル名生成関数群のインターフェイスを統一し、コードの一貫性を向上させます。

## 変更内容
- `generate-gif-output-filename` 関数の引数を `(input &optional opts)` から `(opts)` に変更
- `main.lisp` の GIF モードでの関数呼び出しを修正
- 関連するテストケースを新しい引数形式に更新

## 変更理由
従来、出力ファイル名生成関数群で引数の順序が統一されていませんでした：
- `generate-gif-output-filename(input &optional opts)` ← 不統一
- `generate-merge-output-filename(opts)`
- `generate-output-filename(opts &optional ext)`

この変更により、すべての関数が `opts` を第一引数として受け取るようになり、APIの一貫性が向上します。

## テスト
- 既存のテストケースを新しい引数形式に対応
- 関数の動作に変更はなく、インターフェイスのみの変更

🤖 Generated with [Claude Code](https://claude.ai/code)