### PR TITLE
Post-release cleanup for v0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@
 *.zip
 
 visp
+visp-macos-arm64
+
+# Release files
+CHANGELOG.md
 
 # Ignore ASDF index
 system-index.txt

--- a/visp.asd
+++ b/visp.asd
@@ -1,6 +1,6 @@
 (defsystem "visp"
   :description "Minimal ffmpeg wrapper CLI tool written in Common Lisp"
-  :version "0.2.0"
+  :version "0.3.0"
   :author "ogrew"
   :license "MIT"
   :depends-on (:uiop)


### PR DESCRIPTION
## Summary
- Remove CHANGELOG.md (temporary file used only for release process)
- Add visp-macos-arm64 and CHANGELOG.md to .gitignore to prevent future commits

## Test plan
- [x] Verify CHANGELOG.md is removed
- [x] Verify .gitignore includes new entries
- [x] Build and basic functionality test

🤖 Generated with [Claude Code](https://claude.ai/code)